### PR TITLE
Don't lint on build

### DIFF
--- a/samples/hello-world/package.json
+++ b/samples/hello-world/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "tsc --build --clean",
-    "build": "tslint -p ./tsconfig.json src/**/*.ts && tsc --build",
+    "build": "tsc --build",
     "lint": "tslint -p ./tsconfig.json src/**/*.ts",
     "start": "node .",
     "debug": "node --nolazy --inspect-brk=9229 ."

--- a/samples/solar-system/package.json
+++ b/samples/solar-system/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "tsc --build --clean",
-    "build": "tslint -p ./tsconfig.json src/**/*.ts && tsc --build",
+    "build": "tsc --build",
     "lint": "tslint -p ./tsconfig.json src/**/*.ts",
     "start": "node .",
     "debug": "node --nolazy --inspect-brk=9229 ."


### PR DESCRIPTION
tslint in the build step is important to have in our SDK, but less so in the samples. Errors from tslint can be more confusing than helpful when getting started.