### PR TITLE
Add scripts for swapping between sdk source code and npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <img width='200' height='200' src='https://github.com/Microsoft/mixed-reality-extension-sdk/blob/master/branding/MRe-RGB.png'/>
 
-The Mixed Reality Extension SDK Samples is the easiest way to build and run 
+The Mixed Reality Extension SDK Samples is the easiest way to build and run
 your first [AltspaceVR](https://altvr.com/) extension using the [Mixed Reality
 Extension SDK](
-https://github.com/Microsoft/mixed-reality-extension-sdk). 
+https://github.com/Microsoft/mixed-reality-extension-sdk).
 
 ## Prerequisites
-* Install [Node.js 8.12](https://nodejs.org/download/release/v8.12.0/) or 
+* Install [Node.js 8.12](https://nodejs.org/download/release/v8.12.0/) or
 newer, which includes NPM 6.4.1 or newer, from nodejs.org
 
 ## How to Build and Run the Hello World sample
@@ -27,16 +27,16 @@ In AltspaceVR
 * Click Basics group
 * Click on SDKApp
 * For the URL field, enter `ws://localhost:3901`
-* Enter a session ID (This step will eventually be optional. For now, put in 
+* Enter a session ID (This step will eventually be optional. For now, put in
 any random value)
 * Click Confirm
 * If the app doesn't seem to load, click on the gear icon next the MRE object
 in to the present objects list, and make sure "Is Playing" is checked.
-* After the app has been placed, you will see the MRE Anchor (the white box 
+* After the app has been placed, you will see the MRE Anchor (the white box
 with red/green/blue spikes on it), rendering on top of the MRE. You can use the
 anchor move the MRE around. To hide the anchor, uncheck "Edit Mode".
 
-You should now see the words "Hello World" above a spinning cube. 
+You should now see the words "Hello World" above a spinning cube.
 Congratulations, you have now deployed a Node.js server with the MRE SDK onto
 your local machine and connected to it from AltspaceVR.
 
@@ -65,3 +65,16 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Developing Apps Against SDK Source Code
+
+If you wish to build and debug the samples against the cloced source code for the SDK, we have provided a script to help
+you to point your app to the local source code package of the SDK rather than the one published to NPM.  To do this you
+will first need to clone the [Mixed Reality Extension SDK](https://github.com/Microsoft/mixed-reality-extension-sdk)
+and add a sdk-path-config.json file that contains the json `{ "sdkPath": "<path_to_sdk>"}` where the `<path_to_sdk>` is
+the path to the root of the SDK repo you cloned.  This needs to be added to any of the sample apps that you wish to do this
+for.  Once added you can simply run the following npm scripts to switch between SDK source code and the NPM package for the
+app.
+
+- `npm run use-sdk-source` to use the SDK source code.
+- `npm run use-sdk-npm` to use the SDK NPM package.

--- a/samples/hello-world/.gitignore
+++ b/samples/hello-world/.gitignore
@@ -1,0 +1,1 @@
+sdk-path-config.json

--- a/samples/hello-world/.vscode/launch.json
+++ b/samples/hello-world/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Hello World",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+              "run-script",
+              "debug"
+            ],
+            "port": 9229,
+            "cwd": "${workspaceFolder}",
+            "internalConsoleOptions": "openOnSessionStart",
+            "autoAttachChildProcesses": true
+        }
+    ]
+}

--- a/samples/hello-world/change-sdk-source.js
+++ b/samples/hello-world/change-sdk-source.js
@@ -1,0 +1,42 @@
+var fs = require('fs');
+var shell = require('shelljs');
+
+const helpText = "Usage: change-sdk-source.js <sdk_source_type>\n\n\tWhere <sdk_source_type> is either: npm or sdk-source\n\n" +
+"\tEnsure that there is a 'sdk-path-config.json' containing { \"sdkPath\": \"<path_to_sdk_directory>\" }\n";
+
+function printError(errorMessage) {
+    console.error(`ERROR: ${errorMessage}\n`);
+    console.error(helpText);
+    process.exit(1);
+}
+
+function printHelp() {
+    console.log(helpText);
+    process.exit();
+}
+
+var args = process.argv.slice(2);
+console.log();
+if (args.find(arg => {return (arg === '-h' || arg === '--help')}) !== undefined) {
+    printHelp();
+}
+
+if (args.length === 0) {
+    printError("Must supply an argument of either npm or sdk-source.");
+}
+
+var config = JSON.parse(fs.readFileSync('./sdk-path-config.json', 'utf8'));
+if (!config || !config.sdkPath) {
+    printError("Must provide a valid sdk-path-config.json with a valid sdkPath.");
+}
+
+// update environment to be linked to the local source package, or to be the npm package.
+if (args[0] === 'npm') {
+    shell.exec(`npm unlink ${config.sdkPath} && npm install`);
+} else if (args[0] === 'source') {
+    shell.exec(`npm link ${config.sdkPath}`);
+} else {
+    printError("Invalid command.");
+}
+
+process.exit();

--- a/samples/hello-world/package-lock.json
+++ b/samples/hello-world/package-lock.json
@@ -328,6 +328,12 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ=",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -415,6 +421,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -494,12 +506,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "optional": true
-    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -507,6 +513,14 @@
       "optional": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
+        }
       }
     },
     "moment": {
@@ -615,6 +629,15 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "resolve": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -716,6 +739,33 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
       "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg=="
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
     },
     "spdy": {
       "version": "3.4.7",

--- a/samples/hello-world/package.json
+++ b/samples/hello-world/package.json
@@ -24,12 +24,16 @@
     "build": "tsc --build",
     "lint": "tslint -p ./tsconfig.json src/**/*.ts",
     "start": "node .",
-    "debug": "node --nolazy --inspect-brk=9229 ."
+    "debug": "node --nolazy --inspect-brk=9229 .",
+    "use-sdk-source": "node ./change-sdk-source source",
+    "use-sdk-npm": "node ./change-sdk-source npm"
   },
   "devDependencies": {
     "@types/node": "^10.3.1",
     "tslint": "5.11.0",
-    "typescript": "3.0.3"
+    "typescript": "3.0.3",
+    "fs": "0.0.1-security",
+    "shelljs": "^0.8.3"
   },
   "dependencies": {
     "@microsoft/mixed-reality-extension-sdk": "^0.1.3"

--- a/samples/solar-system/.gitignore
+++ b/samples/solar-system/.gitignore
@@ -1,0 +1,1 @@
+sdk-path-config.json

--- a/samples/solar-system/change-sdk-source.js
+++ b/samples/solar-system/change-sdk-source.js
@@ -1,0 +1,42 @@
+var fs = require('fs');
+var shell = require('shelljs');
+
+const helpText = "Usage: change-sdk-source.js <sdk_source_type>\n\n\tWhere <sdk_source_type> is either: npm or sdk-source\n\n" +
+"\tEnsure that there is a 'sdk-path-config.json' containing { \"sdkPath\": \"<path_to_sdk_directory>\" }\n";
+
+function printError(errorMessage) {
+    console.error(`ERROR: ${errorMessage}\n`);
+    console.error(helpText);
+    process.exit(1);
+}
+
+function printHelp() {
+    console.log(helpText);
+    process.exit();
+}
+
+var args = process.argv.slice(2);
+console.log();
+if (args.find(arg => {return (arg === '-h' || arg === '--help')}) !== undefined) {
+    printHelp();
+}
+
+if (args.length === 0) {
+    printError("Must supply an argument of either npm or sdk-source.");
+}
+
+var config = JSON.parse(fs.readFileSync('./sdk-path-config.json', 'utf8'));
+if (!config || !config.sdkPath) {
+    printError("Must provide a valid sdk-path-config.json with a valid sdkPath.");
+}
+
+// update environment to be linked to the local source package, or to be the npm package.
+if (args[0] === 'npm') {
+    shell.exec(`npm unlink ${config.sdkPath} && npm install`);
+} else if (args[0] === 'source') {
+    shell.exec(`npm link ${config.sdkPath}`);
+} else {
+    printError("Invalid command.");
+}
+
+process.exit();

--- a/samples/solar-system/package-lock.json
+++ b/samples/solar-system/package-lock.json
@@ -328,6 +328,12 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ=",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://microsoft.pkgs.visualstudio.com/_packaging/MicroApps/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -414,6 +420,12 @@
       "version": "2.0.3",
       "resolved": "https://microsoft.pkgs.visualstudio.com/_packaging/MicroApps/npm/registry/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -615,6 +627,15 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "resolve": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -716,6 +737,33 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
       "integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg=="
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
     },
     "spdy": {
       "version": "3.4.7",

--- a/samples/solar-system/package.json
+++ b/samples/solar-system/package.json
@@ -24,12 +24,16 @@
     "build": "tsc --build",
     "lint": "tslint -p ./tsconfig.json src/**/*.ts",
     "start": "node .",
-    "debug": "node --nolazy --inspect-brk=9229 ."
+    "debug": "node --nolazy --inspect-brk=9229 .",
+    "use-sdk-source": "node ./change-sdk-source source",
+    "use-sdk-npm": "node ./change-sdk-source npm"
   },
   "devDependencies": {
     "@types/node": "^10.3.1",
     "tslint": "5.11.0",
-    "typescript": "3.0.3"
+    "typescript": "3.0.3",
+    "fs": "0.0.1-security",
+    "shelljs": "^0.8.3"
   },
   "dependencies": {
     "@microsoft/mixed-reality-extension-sdk": "^0.1.3"


### PR DESCRIPTION
Added in script for swapping between sdk source code and npm packages for sample apps.  Create a sdk-path-config.json file with the json `{ "sdkPath": "<path_to_sdk_root>"}` and you can use the new package scripts like so:

- `npm run use-sdk-source` to use the source code at the path in the config file.
- `npm run use-sdk-npm` to use the published npm package for the sdk.

**NOTE**: You will need to run `npm install` in each of the sample apps after syncing these changes.