### PR TITLE
Housekeeping: Update server.ts to match new conventions in sdk

### DIFF
--- a/samples/hello-world/src/server.ts
+++ b/samples/hello-world/src/server.ts
@@ -3,18 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { log, WebHost } from '@microsoft/mixed-reality-extension-sdk';
+import { WebHost } from '@microsoft/mixed-reality-extension-sdk';
 import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
 
-// Read .env if file exists
-dotenv.config();
-
 process.on('uncaughtException', err => console.log('uncaughtException', err));
 process.on('unhandledRejection', reason => console.log('unhandledRejection', reason));
 
-log.enable('app');
+// Read .env if file exists
+dotenv.config();
 
 // Start listening for connections, and serve static files
 const server = new WebHost({

--- a/samples/solar-system/src/server.ts
+++ b/samples/solar-system/src/server.ts
@@ -3,18 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { log, WebHost } from '@microsoft/mixed-reality-extension-sdk';
+import { WebHost } from '@microsoft/mixed-reality-extension-sdk';
 import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
 
-// Read .env if file exists
-dotenv.config();
-
 process.on('uncaughtException', err => console.log('uncaughtException', err));
 process.on('unhandledRejection', reason => console.log('unhandledRejection', reason));
 
-log.enable('app');
+// Read .env if file exists
+dotenv.config();
 
 // Start listening for connections, and serve static files
 const server = new WebHost({

--- a/samples/tic-tac-toe/src/server.ts
+++ b/samples/tic-tac-toe/src/server.ts
@@ -3,18 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { log, WebHost } from '@microsoft/mixed-reality-extension-sdk';
+import { WebHost } from '@microsoft/mixed-reality-extension-sdk';
 import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
 
-// Read .env if file exists
-dotenv.config();
-
 process.on('uncaughtException', err => console.log('uncaughtException', err));
 process.on('unhandledRejection', reason => console.log('unhandledRejection', reason));
 
-log.enable('app');
+// Read .env if file exists
+dotenv.config();
 
 // Start listening for connections, and serve static files
 const server = new WebHost({

--- a/samples/wear-a-hat/src/server.ts
+++ b/samples/wear-a-hat/src/server.ts
@@ -3,18 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import { log, WebHost } from '@microsoft/mixed-reality-extension-sdk';
+import { WebHost } from '@microsoft/mixed-reality-extension-sdk';
 import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
 
-// Read .env if file exists
-dotenv.config();
-
 process.on('uncaughtException', err => console.log('uncaughtException', err));
 process.on('unhandledRejection', reason => console.log('unhandledRejection', reason));
 
-log.enable('app');
+// Read .env if file exists
+dotenv.config();
 
 // Start listening for connections, and serve static files
 const server = new WebHost({


### PR DESCRIPTION
Remove `log.enable('app')` since it is now enabled by default. Read .env file after setting up global exception handlers.