### PR TITLE
Remove baseUrl references, various touch-ups

### DIFF
--- a/samples/group-mask/.eslintrc.js
+++ b/samples/group-mask/.eslintrc.js
@@ -45,7 +45,6 @@ module.exports = {
 		],
 		"max-classes-per-file": ["warn", 1],
 		"max-len": ["error", 120],
-		"no-console": "error",
 		"no-div-regex": "error",
 		"no-empty": ["error", { "allowEmptyCatch": true }],
 		"no-labels": "error",

--- a/samples/group-mask/public/index.html
+++ b/samples/group-mask/public/index.html
@@ -1,0 +1,1 @@
+<h1>Group mask sample</h1>

--- a/samples/group-mask/public/manifest.json
+++ b/samples/group-mask/public/manifest.json
@@ -1,0 +1,7 @@
+{
+	"name": "Group Mask Sample",
+	"author": "Microsoft",
+	"license": "MIT",
+	"repositoryUrl": "https://github.com/microsoft/mixed-reality-extension-sdk-samples",
+	"optionalPermissions": ["user-interaction"]
+}

--- a/samples/group-mask/src/app.ts
+++ b/samples/group-mask/src/app.ts
@@ -4,136 +4,108 @@
  */
 
 import * as MRE from '@microsoft/mixed-reality-extension-sdk';
-import GroupMaskManager, { ButtonMask } from './groupMaskManager'
-export default class GroupMaskSample {
+import { ButtonMask, GroupMaskManager } from './groupMaskManager';
 
+/**
+ * This sample demonstrates how to manage visibility of objects via a group mask.
+ */
+export default class GroupMaskSample {
+	/** A pool of group masks that we can reuse between users. */
 	private groupMaskManager: GroupMaskManager;
-	
-	//Group of cubes that control their appearance through a user mask, only
-	//users that have the base cube highlighted will be able to see these.
-	//This is a performance advantage to creating a new actor for each user
-	//Highlight cubes are transparent white cubes that appear over top of
-	//the button a user has highlighted, and should only be visible by
-	//the users with it currently selected 
+
+	/**
+	 * Group of cubes that control their appearance through a user mask, only
+	 * users that have the base cube highlighted will be able to see these.
+	 * This is a server performance advantage over creating a new actor for each user.
+	 * Highlight cubes are transparent white cubes that appear over top of
+	 * the button a user has highlighted, and should only be visible by
+	 * the users with it currently selected.
+	 */
 	private highlightCubes: MRE.Actor[] = [];
 
-	//Altspace logo cubes to appear over top of base cubes to indicate
-	//selection, they should only be visible to users who click the black
-	//cube underneath
+	/*
+	 * Altspace logo cubes to appear over top of base cubes to indicate
+	 * selection, they should only be visible to users who click the black
+	 * cube underneath.
+	 */
 	private selectionCubes: MRE.Actor[] = [];
 
-	//Base black cubes are always visibile to all users. Moving your cursor over
-	//the cube results in a white highlight, clicking results in an altspace branded
-	//cube
+	/*
+	 * Base black cubes are always visibile to all users. Moving your cursor over
+	 * the cube results in a white highlight, clicking results in an altspace branded
+	 * cube.
+	 */
 	private baseCubes: MRE.Actor[] = [];
+
+	/** An asset container to store all our models, materials, and textures. */
 	private assets: MRE.AssetContainer;
 
-	//Text above each button
+	/** Text above each button. */
 	private texts: MRE.Actor[] = [];
 
-	constructor(public context: MRE.Context, private baseUrl: string) {
+	constructor(public context: MRE.Context) {
+		// hook up our MRE callbacks
 		this.context.onStarted(() => this.started());
-
 		this.groupMaskManager = new GroupMaskManager(this);
 	}
 
 	private async started() {
+		// create the materials we'll use to differentiate the button cube states
 		this.assets = new MRE.AssetContainer(this.context);
 		const whiteMaterial = this.assets.createMaterial("whiteMat", {
-			color: {r: 1, g: 1, b: 1, a: .7},
+			color: { r: 1, g: 1, b: 1, a: .7 },
 			alphaMode: MRE.AlphaMode.Blend
-		})
+		});
 
 		const blackMaterial = this.assets.createMaterial("blackmat", {
-			color: {r: 0, g: 0, b: 0, a: 1},
-			alphaMode: MRE.AlphaMode.Opaque
-		})
-
-		const baseCube = this.assets.createPrimitiveMesh("cube", {
-			shape: MRE.PrimitiveShape.Box,
-			dimensions: {x:0.4, y:0.4, z:0.4}
+			color: MRE.Color3.Black()
 		});
 
-		let altspaceCubeAssets: MRE.Asset[];
+		const baseCube = this.assets.createBoxMesh("cube", 0.4, 0.4, 0.4);
 
-		await this.assets.loadGltf(`${this.baseUrl}/altspace-cube.glb`).then((asset)=>{
-			altspaceCubeAssets = asset; 
-		});
+		// load our gltf model of the altspace-branded cube
+		let altspaceCubePrefab: MRE.Prefab;
+		try {
+			const altspaceCubeAssets = await this.assets.loadGltf('altspace-cube.glb');
+			altspaceCubePrefab = altspaceCubeAssets.find((asset) => { return asset.prefab !== null }).prefab;
+		} catch (err) {
+			console.log("Failed to load GLB:", err);
+		}
 
-		const altspaceCubePrefab = altspaceCubeAssets.find((asset) => { return asset.prefab !== null })
+		// create an array of buttons
+		for (let i = 0; i < 4; ++i) {
 
-		for(let i = 0; i < 4; ++i) {
-
+			// create the button itself
 			const baseButton = MRE.Actor.Create(this.context, {
 				actor: {
-					transform: {local: {position: { x: -1.5 + i*2, y: .5, z: 0 }}},
+					transform: { local: { position: { x: -1.5 + i * 2, y: .5, z: 0 }}},
+					// it's a black cube
 					appearance: {
 						meshId: baseCube.id,
 						materialId: blackMaterial.id
 					},
-					collider: {
-						enabled: true,
-						geometry: {
-							shape: MRE.ColliderType.Box,
-							size:{x:.4, y:.4, z:.4}
-						},
-						layer: MRE.CollisionLayer.Default
-					}
+					// with an auto-sized collider on it
+					collider: { geometry: { shape: MRE.ColliderType.Auto }}
 				},
 			});
+			this.baseCubes.push(baseButton);
 
+			// let the user click on these boxes like they're buttons
 			const buttonBehavior = baseButton.setBehavior(MRE.ButtonBehavior);
 
+			// when a user clicks a box, add them to that box's clicked group
 			buttonBehavior.onClick(user => {
-				//Behavior to handle user selections goes here
-
-				//Clear all groups and add user to the selected group
 				user.groups.clear();
 				user.groups.add(this.groupMaskManager.getButtonMaskTag(ButtonMask.CLICK_A + i));
 			});
+
+			// when a user hovers the box, add them to the box's hovered group
 			buttonBehavior.onHover('enter', (user) => {
-				//Add hover group to user 
-				user.groups.add( this.groupMaskManager.getButtonMaskTag(ButtonMask.HOVER_A + i));	
+				user.groups.add( this.groupMaskManager.getButtonMaskTag(ButtonMask.HOVER_A + i));
 			});
 			buttonBehavior.onHover('exit', (user) => {
-				//Remove hover group from user
 				user.groups.delete(this.groupMaskManager.getButtonMaskTag(ButtonMask.HOVER_A + i));
 			});
-
-			this.baseCubes.push(baseButton);
-
-			const highlightedButton = MRE.Actor.Create(this.context, {
-				actor: {
-					transform: {local: {
-						scale: {x:1.1, y:1.1, z:1.1},
-						position: { x: -1.5 + 2*i, y: .5, z: 0 }}},
-					appearance: {
-						meshId: baseCube.id,
-						materialId: whiteMaterial.id
-					},
-				},
-			});
-
-
-			highlightedButton.appearance.enabled = this.groupMaskManager.getButtonMask(ButtonMask.HOVER_A + i); 
-			this.highlightCubes.push(highlightedButton);
-
-			//Load a glTF model for the selected state
-			const selectedCube = MRE.Actor.CreateFromPrefab(this.context,{
-				prefabId: altspaceCubePrefab.id,
-				actor:{
-					name: 'Altspace Cube',
-					transform: {
-						local: {
-							position: { x: -1.5 + 2*i, y: .5, z: 0 },
-							scale: { x: 0.4, y: 0.4, z: 0.4 }
-						}
-					},
-					parentId: baseCube.id
-				}});
-
-			selectedCube.appearance.enabled = this.groupMaskManager.getButtonMask(ButtonMask.CLICK_A + i);
-			this.selectionCubes.push( selectedCube );
 
 			// Create a new actor with no mesh, but some text.
 			this.texts.push(MRE.Actor.Create(this.context, {
@@ -151,6 +123,47 @@ export default class GroupMaskSample {
 					},
 				}
 			}));
+
+			// create the button selection highlight
+			const highlightedButton = MRE.Actor.Create(this.context, {
+				actor: {
+					transform: { local: {
+						scale: { x: 1.1, y: 1.1, z: 1.1 },
+						position: { x: -1.5 + 2 * i, y: .5, z: 0 }}
+					},
+					appearance: {
+						meshId: baseCube.id,
+						materialId: whiteMaterial.id
+					}
+				}
+			});
+			this.highlightCubes.push(highlightedButton);
+
+			// make the highlight only show up for the users that are currently hovering the button
+			highlightedButton.appearance.enabled = this.groupMaskManager.getButtonMask(ButtonMask.HOVER_A + i);
+
+			// only create the branded cubes if we successfully loaded the GLB earlier
+			if (!altspaceCubePrefab) { continue; }
+
+			// create the branded cube
+			const selectedCube = MRE.Actor.CreateFromPrefab(this.context, {
+				// we obtained this prefab from loading the GLB model earlier
+				prefabId: altspaceCubePrefab.id,
+				actor:{
+					name: 'Altspace Cube',
+					transform: {
+						local: {
+							position: { x: -1.5 + 2 * i, y: .5, z: 0 },
+							scale: { x: 0.4, y: 0.4, z: 0.4 }
+						}
+					},
+					parentId: baseCube.id
+				}
+			});
+			this.selectionCubes.push(selectedCube);
+
+			// make the branded cube only show up for users that click the button
+			selectedCube.appearance.enabled = this.groupMaskManager.getButtonMask(ButtonMask.CLICK_A + i);
 		}
 	}
 }

--- a/samples/group-mask/src/groupMaskManager.ts
+++ b/samples/group-mask/src/groupMaskManager.ts
@@ -6,56 +6,59 @@
 import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 import GroupMaskSample from './app';
 
+/** An enumeration of the different states a user can be in for particular controls. */
 export enum ButtonMask {
+	/** The user isn't hovering over A */
 	DEFAULT_A = 0,
+	/** The user isn't hovering over B */
 	DEFAULT_B,
+	/** The user isn't hovering over C */
 	DEFAULT_C,
+	/** The user isn't hovering over D */
 	DEFAULT_D,
+	/** The user is hovering over A */
 	HOVER_A,
+	/** The user is hovering over B */
 	HOVER_B,
+	/** The user is hovering over C */
 	HOVER_C,
+	/** The user is hovering over D */
 	HOVER_D,
+	/** The user is clicking on A */
 	CLICK_A,
+	/** The user is clicking on B */
 	CLICK_B,
+	/** The user is clicking on C */
 	CLICK_C,
+	/** The user is clicking on D */
 	CLICK_D,
+	/** The last value, used for looping over this enum */
 	MAX
 }
 
-export enum OtherMask {
-	CUSTOM_1 = ButtonMask.MAX,
-	MAX
-}
+/** Reuses group masks for multiple objects, so a user can be added to a group and get a whole set of objects. */
+export class GroupMaskManager {
+	private static readonly PREFIX = 'MASK_';
 
-export enum JoinMask {
-	DEFAULT = ButtonMask.DEFAULT_A,
-	HOVER = ButtonMask.HOVER_A,
-	CLICK = ButtonMask.CLICK_A,
-	LEAVE = ButtonMask.DEFAULT_B,
-	LEAVE_HOVER = ButtonMask.HOVER_B
-}
-
-export default class GroupMaskManager {
+	/** Keep a list of the group masks so we can reuse them. */
 	private masks: MRE.GroupMask[];
-	private readonly PREFIX = 'MASK_';
 
 	public constructor(app: GroupMaskSample) {
+		// construct the various masks we'll need in advance
 		this.masks = [];
-		for (let i = 0; i < OtherMask.MAX; i++) {
-			const mask = new MRE.GroupMask(app.context, ['MASK_' + i]);
+		for (let i = 0; i < ButtonMask.MAX; i++) {
+			const mask = new MRE.GroupMask(app.context, [this.getButtonMaskTag(i)]);
 			this.masks.push(mask);
 		}
 	}
 
-	public getButtonMask(i: ButtonMask | JoinMask): MRE.GroupMask {
+	/** Fetch the mask for a particular user action */
+	public getButtonMask(i: ButtonMask): MRE.GroupMask {
 		return this.masks[i];
 	}
 
-	public getButtonMaskTag(i: ButtonMask | JoinMask): string {
-		return this.PREFIX + i.toString();
-	}
-
-	public get joinGroup(): string {
-		return this.getButtonMaskTag(JoinMask.LEAVE);
+	/** Fetch the ID of the mask for a particular user action */
+	public getButtonMaskTag(i: ButtonMask): string {
+		return GroupMaskManager.PREFIX + i.toString();
 	}
 }

--- a/samples/group-mask/src/server.ts
+++ b/samples/group-mask/src/server.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { WebHost } from '@microsoft/mixed-reality-extension-sdk';
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
@@ -21,7 +21,7 @@ dotenv.config();
 // the server starts accepting connections.
 function runApp() {
 	// Start listening for connections, and serve static files from the given folder
-	const server = new WebHost({
+	const server = new MRE.WebHost({
 		baseDir: resolvePath(__dirname, '../public')
 	});
 

--- a/samples/group-mask/src/server.ts
+++ b/samples/group-mask/src/server.ts
@@ -8,10 +8,9 @@ import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
 
-/* eslint-disable no-console */
+// add some generic error handlers here, to log any exceptions we're not expecting
 process.on('uncaughtException', err => console.log('uncaughtException', err));
 process.on('unhandledRejection', reason => console.log('unhandledRejection', reason));
-/* eslint-enable no-console */
 
 // Read .env if file exists
 dotenv.config();
@@ -21,14 +20,13 @@ dotenv.config();
 // small delay is introduced allowing time for the debugger to attach before
 // the server starts accepting connections.
 function runApp() {
-	// Start listening for connections, and serve static files.
+	// Start listening for connections, and serve static files from the given folder
 	const server = new WebHost({
-		// baseUrl: 'http://<ngrok-id>.ngrok.io',
 		baseDir: resolvePath(__dirname, '../public')
 	});
 
 	// Handle new application sessions
-	server.adapter.onConnection(context => new App(context, server.baseUrl));
+	server.adapter.onConnection(context => new App(context));
 }
 
 // Check whether code is running in a debuggable watched filesystem

--- a/samples/hello-world/.eslintrc.js
+++ b/samples/hello-world/.eslintrc.js
@@ -45,7 +45,6 @@ module.exports = {
 		],
 		"max-classes-per-file": ["warn", 1],
 		"max-len": ["error", 120],
-		"no-console": "error",
 		"no-div-regex": "error",
 		"no-empty": ["error", { "allowEmptyCatch": true }],
 		"no-labels": "error",

--- a/samples/hello-world/public/manifest.json
+++ b/samples/hello-world/public/manifest.json
@@ -1,0 +1,7 @@
+{
+	"name": "Hello World Sample",
+	"author": "Microsoft",
+	"license": "MIT",
+	"repositoryUrl": "https://github.com/microsoft/mixed-reality-extension-sdk-samples",
+	"optionalPermissions": ["user-interaction"]
+}

--- a/samples/hello-world/src/server.ts
+++ b/samples/hello-world/src/server.ts
@@ -3,15 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { Permissions, WebHost } from '@microsoft/mixed-reality-extension-sdk';
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
 
-/* eslint-disable no-console */
+// add some generic error handlers here, to log any exceptions we're not expecting
 process.on('uncaughtException', err => console.log('uncaughtException', err));
 process.on('unhandledRejection', reason => console.log('unhandledRejection', reason));
-/* eslint-enable no-console */
 
 // Read .env if file exists
 dotenv.config();
@@ -22,14 +21,12 @@ dotenv.config();
 // the server starts accepting connections.
 function runApp() {
 	// Start listening for connections, and serve static files.
-	const server = new WebHost({
-		// baseUrl: 'http://<ngrok-id>.ngrok.io',
-		baseDir: resolvePath(__dirname, '../public'),
-		optionalPermissions: [Permissions.UserInteraction]
+	const server = new MRE.WebHost({
+		baseDir: resolvePath(__dirname, '../public')
 	});
 
 	// Handle new application sessions
-	server.adapter.onConnection(context => new App(context, server.baseUrl));
+	server.adapter.onConnection(context => new App(context));
 }
 
 // Check whether code is running in a debuggable watched filesystem

--- a/samples/solar-system/.eslintrc.js
+++ b/samples/solar-system/.eslintrc.js
@@ -45,7 +45,6 @@ module.exports = {
 		],
 		"max-classes-per-file": ["warn", 1],
 		"max-len": ["error", 120],
-		"no-console": "error",
 		"no-div-regex": "error",
 		"no-empty": ["error", { "allowEmptyCatch": true }],
 		"no-labels": "error",

--- a/samples/solar-system/public/manifest.json
+++ b/samples/solar-system/public/manifest.json
@@ -1,0 +1,7 @@
+{
+	"name": "Solar System Sample",
+	"author": "Microsoft",
+	"license": "MIT",
+	"repositoryUrl": "https://github.com/microsoft/mixed-reality-extension-sdk-samples",
+	"optionalPermissions": ["user-interaction"]
+}

--- a/samples/solar-system/src/app.ts
+++ b/samples/solar-system/src/app.ts
@@ -49,7 +49,7 @@ export default class SolarSystem {
 	private animationsRunning = false;
 	private assets: MRE.AssetContainer;
 
-	constructor(private context: MRE.Context, private baseUrl: string) {
+	constructor(private context: MRE.Context) {
 		this.assets = new MRE.AssetContainer(context);
 		this.context.onStarted(() => this.started());
 	}
@@ -124,7 +124,9 @@ export default class SolarSystem {
 		}
 	}
 
-	private createBody(bodyName: string) {
+	// this function is "async", meaning that it returns a promise
+	// (even though we don't use that promise in this sample).
+	private async createBody(bodyName: string) {
 
 		const facts = database[bodyName];
 
@@ -188,8 +190,16 @@ export default class SolarSystem {
 					}
 				}
 			});
-			const model = MRE.Actor.CreateFromGltf(this.assets, {
-				uri: `${this.baseUrl}/assets/${bodyName}.gltf`,
+
+			// load the model if it hasn't been already
+			let prefab = this.assets.prefabs.find(p => p.source.uri === `assets/${bodyName}.gltf`);
+			if (!prefab) {
+				const modelData = await this.assets.loadGltf(`assets/${bodyName}.gltf`, "box");
+				prefab = modelData.find(a => a.prefab !== undefined).prefab;
+			}
+
+			const model = MRE.Actor.CreateFromPrefab(this.context, {
+				prefab: prefab,
 				actor: {
 					name: `${bodyName}-body`,
 					parentId: obliquity1.id,
@@ -203,7 +213,6 @@ export default class SolarSystem {
 						}
 					}
 				}
-
 			});
 
 			label.enableText({

--- a/samples/solar-system/src/app.ts
+++ b/samples/solar-system/src/app.ts
@@ -195,7 +195,7 @@ export default class SolarSystem {
 			let prefab = this.assets.prefabs.find(p => p.source.uri === `assets/${bodyName}.gltf`);
 			if (!prefab) {
 				const modelData = await this.assets.loadGltf(`assets/${bodyName}.gltf`, "box");
-				prefab = modelData.find(a => a.prefab !== undefined).prefab;
+				prefab = modelData.find(a => a.prefab !== null).prefab;
 			}
 
 			const model = MRE.Actor.CreateFromPrefab(this.context, {

--- a/samples/solar-system/src/server.ts
+++ b/samples/solar-system/src/server.ts
@@ -3,15 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { Permissions, WebHost } from '@microsoft/mixed-reality-extension-sdk';
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
 
-/* eslint-disable no-console */
+// add some generic error handlers here, to log any exceptions we're not expecting
 process.on('uncaughtException', err => console.log('uncaughtException', err));
 process.on('unhandledRejection', reason => console.log('unhandledRejection', reason));
-/* eslint-enable no-console */
 
 // Read .env if file exists
 dotenv.config();
@@ -22,14 +21,12 @@ dotenv.config();
 // the server starts accepting connections.
 function runApp() {
 	// Start listening for connections, and serve static files.
-	const server = new WebHost({
-		// baseUrl: 'http://<ngrok-id>.ngrok.io',
-		baseDir: resolvePath(__dirname, '../public'),
-		optionalPermissions: [Permissions.UserInteraction]
+	const server = new MRE.WebHost({
+		baseDir: resolvePath(__dirname, '../public')
 	});
 
 	// Handle new application sessions
-	server.adapter.onConnection(context => new App(context, server.baseUrl));
+	server.adapter.onConnection(context => new App(context));
 }
 
 // Check whether code is running in a debuggable watched filesystem

--- a/samples/tic-tac-toe/.eslintrc.js
+++ b/samples/tic-tac-toe/.eslintrc.js
@@ -45,7 +45,6 @@ module.exports = {
 		],
 		"max-classes-per-file": ["warn", 1],
 		"max-len": ["error", 120],
-		"no-console": "error",
 		"no-div-regex": "error",
 		"no-empty": ["error", { "allowEmptyCatch": true }],
 		"no-labels": "error",

--- a/samples/tic-tac-toe/public/manifest.json
+++ b/samples/tic-tac-toe/public/manifest.json
@@ -1,0 +1,7 @@
+{
+	"name": "Tic-Tac-Toe Sample",
+	"author": "Microsoft",
+	"license": "MIT",
+	"repositoryUrl": "https://github.com/microsoft/mixed-reality-extension-sdk-samples",
+	"optionalPermissions": ["user-interaction"]
+}

--- a/samples/tic-tac-toe/src/app.ts
+++ b/samples/tic-tac-toe/src/app.ts
@@ -44,7 +44,7 @@ export default class TicTacToe {
 		[2 * 3 + 0, 1 * 3 + 1, 0 * 3 + 2]
 	];
 
-	constructor(private context: MRE.Context, private baseUrl: string) {
+	constructor(private context: MRE.Context) {
 		this.assets = new MRE.AssetContainer(context);
 		this.context.onStarted(() => this.started());
 	}
@@ -166,7 +166,7 @@ export default class TicTacToe {
 		}]});
 
 		// Load box model from glTF
-		const gltf = await this.assets.loadGltf(`${this.baseUrl}/altspace-cube.glb`, 'box');
+		const gltf = await this.assets.loadGltf('altspace-cube.glb', 'box');
 
 		// Also load the player choice markers now, for efficiency's sake
 		const circle = this.assets.createCylinderMesh('circle', 0.2, 0.4, 'y', 16);

--- a/samples/tic-tac-toe/src/server.ts
+++ b/samples/tic-tac-toe/src/server.ts
@@ -3,15 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { Permissions, WebHost } from '@microsoft/mixed-reality-extension-sdk';
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
 
-/* eslint-disable no-console */
+// add some generic error handlers here, to log any exceptions we're not expecting
 process.on('uncaughtException', err => console.log('uncaughtException', err));
 process.on('unhandledRejection', reason => console.log('unhandledRejection', reason));
-/* eslint-enable no-console */
 
 // Read .env if file exists
 dotenv.config();
@@ -22,14 +21,13 @@ dotenv.config();
 // the server starts accepting connections.
 function runApp() {
 	// Start listening for connections, and serve static files.
-	const server = new WebHost({
+	const server = new MRE.WebHost({
 		// baseUrl: 'http://<ngrok-id>.ngrok.io',
-		baseDir: resolvePath(__dirname, '../public'),
-		optionalPermissions: [Permissions.UserInteraction]
+		baseDir: resolvePath(__dirname, '../public')
 	});
 
 	// Handle new application sessions
-	server.adapter.onConnection(context => new App(context, server.baseUrl));
+	server.adapter.onConnection(context => new App(context));
 }
 
 // Check whether code is running in a debuggable watched filesystem

--- a/samples/wear-a-hat/.eslintrc.js
+++ b/samples/wear-a-hat/.eslintrc.js
@@ -45,7 +45,6 @@ module.exports = {
 		],
 		"max-classes-per-file": ["warn", 1],
 		"max-len": ["error", 120],
-		"no-console": "error",
 		"no-div-regex": "error",
 		"no-empty": ["error", { "allowEmptyCatch": true }],
 		"no-labels": "error",

--- a/samples/wear-a-hat/public/manifest.json
+++ b/samples/wear-a-hat/public/manifest.json
@@ -1,0 +1,7 @@
+{
+	"name": "Wear A Hat Sample",
+	"author": "Microsoft",
+	"license": "MIT",
+	"repositoryUrl": "https://github.com/microsoft/mixed-reality-extension-sdk-samples",
+	"optionalPermissions": ["user-interaction"]
+}

--- a/samples/wear-a-hat/src/app.ts
+++ b/samples/wear-a-hat/src/app.ts
@@ -54,7 +54,7 @@ export default class WearAHat {
 	 * @param context The MRE SDK context.
 	 * @param baseUrl The baseUrl to this project's `./public` folder.
 	 */
-	constructor(private context: MRE.Context, private baseUrl: string) {
+	constructor(private context: MRE.Context) {
 		this.assets = new MRE.AssetContainer(context);
 		// Hook the context events we're interested in.
 		this.context.onStarted(() => this.started());
@@ -188,8 +188,7 @@ export default class WearAHat {
 			Object.keys(HatDatabase).map(hatId => {
 				const hatRecord = HatDatabase[hatId];
 				if (hatRecord.resourceName) {
-					return this.assets.loadGltf(
-						`${this.baseUrl}/${hatRecord.resourceName}`)
+					return this.assets.loadGltf(hatRecord.resourceName)
 						.then(assets => {
 							this.prefabs[hatId] = assets.find(a => a.prefab !== null) as MRE.Prefab;
 						})
@@ -218,7 +217,7 @@ export default class WearAHat {
 
 		// Create the hat model and attach it to the avatar's head.
 		this.attachedHats.set(userId, MRE.Actor.CreateFromPrefab(this.context, {
-			prefabId: this.prefabs[hatId].id,
+			prefab: this.prefabs[hatId],
 			actor: {
 				transform: {
 					local: {

--- a/samples/wear-a-hat/src/server.ts
+++ b/samples/wear-a-hat/src/server.ts
@@ -3,15 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { Permissions, WebHost } from '@microsoft/mixed-reality-extension-sdk';
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 import dotenv from 'dotenv';
 import { resolve as resolvePath } from 'path';
 import App from './app';
 
-/* eslint-disable no-console */
+// add some generic error handlers here, to log any exceptions we're not expecting
 process.on('uncaughtException', err => console.log('uncaughtException', err));
 process.on('unhandledRejection', reason => console.log('unhandledRejection', reason));
-/* eslint-enable no-console */
 
 // Read .env if file exists
 dotenv.config();
@@ -22,14 +21,13 @@ dotenv.config();
 // the server starts accepting connections.
 function runApp() {
 	// Start listening for connections, and serve static files.
-	const server = new WebHost({
+	const server = new MRE.WebHost({
 		// baseUrl: 'http://<ngrok-id>.ngrok.io',
-		baseDir: resolvePath(__dirname, '../public'),
-		optionalPermissions: [Permissions.UserInteraction]
+		baseDir: resolvePath(__dirname, '../public')
 	});
 
 	// Handle new application sessions
-	server.adapter.onConnection(context => new App(context, server.baseUrl));
+	server.adapter.onConnection(context => new App(context));
 }
 
 // Check whether code is running in a debuggable watched filesystem


### PR DESCRIPTION
* Remove unnecessary base URLs from samples
* Remove the `no-console` rule from all samples' eslint files. Console logs are a great teaching tool, and lots of beginners confuse the lint errors for compile errors.
* Add manifests to all samples
* Stop using `CreateFromGltf`, preferring the more explicit `loadGltf` and `CreateFromPrefab`
* Add comments, cleanup to group mask sample